### PR TITLE
added app-service to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-services: app-service\mobile, app-service\web
+services: app-service\mobile, app-service\web, app-service
 platforms: dotnet, xamarin
 author: lindydonna
 ---


### PR DESCRIPTION
Since app-service\mobile is apparently no longer supported in the Samples site.
